### PR TITLE
Change doc links to RTD

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -123,7 +123,7 @@
                                 </a>
                             </li>
                             <li>
-                                <a class="m-icon icon-block" href="/user-guide/" target="_blank">
+                                <a class="m-icon icon-block" href="https://frrouting.readthedocs.io/en/latest" target="_blank">
                                     <figure><img src="/static/img/icons/icon-user-guide.png" draggable="false" alt=""></figure>
                                     <h3>User Guide</h3>
                                 </a>
@@ -183,7 +183,7 @@
                     <div class="row">
                         <ul class="m-icon-list center-blocks">
                             <li>
-                                <a class="m-icon icon-block" href="https://github.com/FRRouting/frr/blob/master/doc/developer/workflow.rst" target="_blank">
+                                <a class="m-icon icon-block" href="http://frrouting.readthedocs.io/projects/dev-guide/en/latest/" target="_blank">
                                     <figure><img src="/static/img/icons/icon-developing-frr.png" draggable="false" alt=""></figure>
                                     <h3>Developing<br> for FRR</h3>
                                 </a>


### PR DESCRIPTION
[Read The Docs](https://readthedocs.org/) is a free documentation host widely used by open source projects. It builds Sphinx docs and supports features we need including branch based versioning. It uses GitHub webhooks and builds the docs automatically every time they are updated. At some point in the future we can also setup a CNAME to them (which they support), something like `docs.frrouting.org`.

I have set up our two docs here:
[User Guide](https://frrouting.readthedocs.io/en/latest)
[Dev Guide](https://frrouting.readthedocs.io/projects/dev-guide/en/latest)

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>