### PR TITLE
Change slack link to self-serve invite link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -190,7 +190,7 @@
 				<figure><img src="/static/img/icons/icon-dev-email.png" draggable="false" alt=""></figure>
                                     <h3>Security</h3>
                             <li>
-                                <a class="m-icon icon-block" href="https://frrouting.slack.com/" target="_blank">
+                                <a class="m-icon icon-block" href="https://join.slack.com/t/frrouting/shared_invite/enQtNTg5ODM4Mzc3Njg3LTQ3YjQ1M2M2ZGFhYmI2ZjVlN2YxYjg1ODI3NGNiNzVkMTBlMTZhMzNiMWNhMGUwYjNjM2Y2YWFhODgwY2QzNGI" target="_blank">
                                     <figure><img src="/static/img/icons/icon-slack.png" draggable="false" alt=""></figure>
                                     <h3>Slack</h3>
                                 </a>


### PR DESCRIPTION
Apparently slack quietly rolled out this feature a few months ago. It will need to be updated monthly.