### PR TITLE
Fix the link for TSC

### DIFF
--- a/content/community/maintainers.md
+++ b/content/community/maintainers.md
@@ -28,7 +28,7 @@ FRR maintainers have commit access to the [FRR git repositories](https://github.
 
 # Technical Steering Committee
 
-[Technical Steering Committee](tsc.html) Members are responsible for technical oversight of FRRouting Project.
+[Technical Steering Committee](/community/tsc) Members are responsible for technical oversight of FRRouting Project.
 
 The current members of the TSC are:
 


### PR DESCRIPTION
Leading to 404 (tsc.html does not exist).

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>