### PR TITLE
Add recent CVEs to the frrouting.org/security list

### DIFF
--- a/content/security/CVE-2022-36440.md
+++ b/content/security/CVE-2022-36440.md
@@ -1,0 +1,10 @@
+---
+title: CVE-2022-36440
+affecting:
+  - < 8.4
+reported: 2023-04-03
+severity: High
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286](https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286)

--- a/content/security/CVE-2022-37032.md
+++ b/content/security/CVE-2022-37032.md
@@ -1,0 +1,10 @@
+---
+title: CVE-2022-37032
+affecting:
+  - < 8.4
+reported: 2022-09-19
+severity: Critical
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/ff6db1027f8f36df657ff2e5ea167773752537ed](https://github.com/FRRouting/frr/commit/ff6db1027f8f36df657ff2e5ea167773752537ed)

--- a/content/security/CVE-2022-40302.md
+++ b/content/security/CVE-2022-40302.md
@@ -1,0 +1,12 @@
+---
+title: CVE-2022-40302
+affecting:
+  - < 8.4
+reported: 2023-05-03
+severity: Medium
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/1117baca3c592877a4d8a13ed6a1d9bd83977487](https://github.com/FRRouting/frr/commit/1117baca3c592877a4d8a13ed6a1d9bd83977487)
+- [https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286](https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286)
+- [https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78](https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78)

--- a/content/security/CVE-2022-40318.md
+++ b/content/security/CVE-2022-40318.md
@@ -1,0 +1,12 @@
+---
+title: CVE-2022-40318
+affecting:
+  - < 8.4
+reported: 2023-05-03
+severity: Medium
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/1117baca3c592877a4d8a13ed6a1d9bd83977487](https://github.com/FRRouting/frr/commit/1117baca3c592877a4d8a13ed6a1d9bd83977487)
+- [https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286](https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286)
+- [https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78](https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78)

--- a/content/security/CVE-2022-42917.md
+++ b/content/security/CVE-2022-42917.md
@@ -1,0 +1,10 @@
+---
+title: CVE-2022-42917
+affecting:
+  - < 8.4
+reported: 2022-10-07
+severity: Medium
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/972cdc560e339d70c0ee5fb70ec636ab78f00bca](https://github.com/FRRouting/frr/commit/972cdc560e339d70c0ee5fb70ec636ab78f00bca)

--- a/content/security/CVE-2022-43681.md
+++ b/content/security/CVE-2022-43681.md
@@ -1,0 +1,12 @@
+---
+title: CVE-2022-43681
+affecting:
+  - < 8.4
+reported: 2023-05-03
+severity: Medium
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/1117baca3c592877a4d8a13ed6a1d9bd83977487](https://github.com/FRRouting/frr/commit/1117baca3c592877a4d8a13ed6a1d9bd83977487)
+- [https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286](https://github.com/FRRouting/frr/commit/3e46b43e3788f0f87bae56a86b54d412b4710286)
+- [https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78](https://github.com/FRRouting/frr/commit/766eec1b7accffe2c04a5c9ebb14e9f487bb9f78)

--- a/content/security/CVE-2023-38802.md
+++ b/content/security/CVE-2023-38802.md
@@ -1,0 +1,11 @@
+---
+title: CVE-2023-38802
+affecting:
+  - < 8.5.3
+  - 9.0.0
+reported: 2023-08-29
+severity: High
+---
+
+### References:
+- [https://github.com/FRRouting/frr/pull/14290/commits/bcb6b58d9530173df41d3a3cbc4c600ee0b4b186](https://github.com/FRRouting/frr/pull/14290/commits/bcb6b58d9530173df41d3a3cbc4c600ee0b4b186)

--- a/content/security/CVE-2023-41359.md
+++ b/content/security/CVE-2023-41359.md
@@ -1,0 +1,11 @@
+---
+title: CVE-2023-41359
+affecting:
+  - 8.5.0 ~ 8.5.2
+  - 9.0.0
+reported: 2023-08-29
+severity: Critical
+---
+
+### References:
+- [https://github.com/FRRouting/frr/pull/14232/commits/f96201e104892e18493f24cf67bb713678e8237b](https://github.com/FRRouting/frr/pull/14232/commits/f96201e104892e18493f24cf67bb713678e8237b)

--- a/content/security/CVE-2023-41360.md
+++ b/content/security/CVE-2023-41360.md
@@ -1,0 +1,12 @@
+---
+title: CVE-2023-41360
+affecting:
+  - 8.4.x
+  - 8.5.0 ~ 8.5.2
+  - 9.0.0
+reported: 2023-08-29
+severity: Critical
+---
+
+### References:
+- [https://github.com/FRRouting/frr/pull/14245/commits/9b855a692e68e0d16467e190b466b4ecb6853702](https://github.com/FRRouting/frr/pull/14245/commits/9b855a692e68e0d16467e190b466b4ecb6853702)

--- a/content/security/CVE-2023-41361.md
+++ b/content/security/CVE-2023-41361.md
@@ -1,0 +1,10 @@
+---
+title: CVE-2023-41361
+affecting:
+  - 9.0.0
+reported: 2023-08-29
+severity: Critical
+---
+
+### References:
+- [https://github.com/FRRouting/frr/pull/14241/commits/b4d09af9194d20a7f9f16995a062f5d8e3d32840](https://github.com/FRRouting/frr/pull/14241/commits/b4d09af9194d20a7f9f16995a062f5d8e3d32840)


### PR DESCRIPTION
People are asking where can they find references what CVEs and versions are affected. To avoid repetitive answers, let's get put them here.