### PR TITLE
Split CVE-2023-47235 into separate CVEs

### DIFF
--- a/content/security/CVE-2023-46752.md
+++ b/content/security/CVE-2023-46752.md
@@ -1,0 +1,11 @@
+---
+title: CVE-2023-46752
+affecting:
+  - < 8.5.4
+  - 9.0.0 ~ 9.0.1
+reported: 2023-11-03
+severity: High
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/b08afc81c60607a4f736f418f2e3eb06087f1a35](https://github.com/FRRouting/frr/commit/b08afc81c60607a4f736f418f2e3eb06087f1a35)

--- a/content/security/CVE-2023-46753.md
+++ b/content/security/CVE-2023-46753.md
@@ -1,0 +1,11 @@
+---
+title: CVE-2023-46753
+affecting:
+  - < 8.5.4
+  - 9.0.0 ~ 9.0.1
+reported: 2023-11-03
+severity: High
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/d8482bf011cb2b173e85b65b4bf3d5061250cdb9](https://github.com/FRRouting/frr/commit/d8482bf011cb2b173e85b65b4bf3d5061250cdb9)

--- a/content/security/CVE-2023-47234.md
+++ b/content/security/CVE-2023-47234.md
@@ -1,0 +1,11 @@
+---
+title: CVE-2023-47234
+affecting:
+  - < 8.5.4
+  - 9.0.0 ~ 9.0.1
+reported: 2023-11-03
+severity: High
+---
+
+### References:
+- [https://github.com/FRRouting/frr/commit/c37119df45bbf4ef713bc10475af2ee06e12f3bf](https://github.com/FRRouting/frr/commit/c37119df45bbf4ef713bc10475af2ee06e12f3bf)

--- a/content/security/CVE-2023-47235.md
+++ b/content/security/CVE-2023-47235.md
@@ -1,13 +1,11 @@
 ---
 title: CVE-2023-47235
 affecting:
-  - < 9.0.1
+  - < 8.5.4
+  - 9.0.0 ~ 9.0.1
 reported: 2023-11-03
 severity: High
 ---
 
 ### References:
-- [https://github.com/FRRouting/frr/pull/14716/commits/c37119df45bbf4ef713bc10475af2ee06e12f3bf](https://github.com/FRRouting/frr/pull/14716/commits/c37119df45bbf4ef713bc10475af2ee06e12f3bf)
-- [https://github.com/FRRouting/frr/pull/14716/commits/6814f2e0138a6ea5e1f83bdd9085d9a77999900b](https://github.com/FRRouting/frr/pull/14716/commits/6814f2e0138a6ea5e1f83bdd9085d9a77999900b)
-- [https://github.com/FRRouting/frr/pull/14645/commits/b08afc81c60607a4f736f418f2e3eb06087f1a35](https://github.com/FRRouting/frr/pull/14645/commits/b08afc81c60607a4f736f418f2e3eb06087f1a35)
-- [https://github.com/FRRouting/frr/pull/14645/commits/d8482bf011cb2b173e85b65b4bf3d5061250cdb9](https://github.com/FRRouting/frr/pull/14645/commits/d8482bf011cb2b173e85b65b4bf3d5061250cdb9)
+- [https://github.com/FRRouting/frr/commit/6814f2e0138a6ea5e1f83bdd9085d9a77999900b](https://github.com/FRRouting/frr/commit/6814f2e0138a6ea5e1f83bdd9085d9a77999900b)


### PR DESCRIPTION
Actually all those CVEs are related each other, but let's split them for the visibility.